### PR TITLE
Possible Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,8 @@ In this way, the health check request is handled as light as possible, it won't 
 - `respond_func` - a function:
   - accepts two arguments: `%Plug.Conn{}` and the result from the `check_func`.
   - returns a `%Plug.Conn{}`.
+
+
+## License
+
+[MIT](./LICENSE)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Add `plug_health` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:plug_health, "~> 0.1.0"}
+    {:plug_health, "~> 1.0.0"}
   ]
 end
 ```

--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
 # PlugHealth
 
-Respond to health checks without needing a route or controller action.
-
-Optionally, add the health check plug in your endpoint before `Plug.Logger` in order to respond
-to health checks without adding noise to your logs.
+> A plug for health check, which can be used for liveness or readiness probes.
 
 ## Installation
 
@@ -17,14 +14,29 @@ def deps do
 end
 ```
 
-Call the plug in your `endpoint.ex`
+## Usage
+
+It's better to reduce the impact of health check on application, so it's common to add this plug to the header of the endpoint.
+
+For example:
 
 ```elixir
-plug PlugHealth, path: "/alive"
+defmodule DemoWeb.Endpoint do
+  use Phoenix.Endpoint, otp_app: :demo
+
+  # Put the plug here, before anything else
+  plug PlugHealth, path: "/alive"
+end
 ```
 
-### Options
-- `path` - The request path
-- `check_func` - A function that accepts one argument: `Plug.Conn` and, by default, returns a boolean as the result.
-- `respond_func` - A function that accepts two arguments: `Plug.Conn` and the result from the `check_func`. This function
-must return a `Plug.Conn`.
+In this way, the health check request is handled as light as possible, it won't pass through unnecessary plugs, such as request logger, route and controller, etc.
+
+## Options
+
+- `path` - the request path
+- `check_func` - a function:
+  - accepts one argument: `%Plug.Conn{}`.
+  - returns a boolean as the result.
+- `respond_func` - a function:
+  - accepts two arguments: `%Plug.Conn{}` and the result from the `check_func`.
+  - returns a `%Plug.Conn{}`.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# HealthCheckPlug
+# PlugHealth
 
 Respond to health checks without needing a route or controller action.
 
@@ -20,7 +20,7 @@ end
 Call the plug in your `endpoint.ex`
 
 ```elixir
-plug HealthCheckPlug, path: "/alive"
+plug PlugHealth, path: "/alive"
 ```
 
 ### Options
@@ -28,4 +28,3 @@ plug HealthCheckPlug, path: "/alive"
 - `check_func` - A function that accepts one argument: `Plug.Conn` and, by default, returns a boolean as the result.
 - `respond_func` - A function that accepts two arguments: `Plug.Conn` and the result from the `check_func`. This function
 must return a `Plug.Conn`.
-

--- a/lib/plug_health.ex
+++ b/lib/plug_health.ex
@@ -1,4 +1,4 @@
-defmodule HealthCheckPlug do
+defmodule PlugHealth do
   @moduledoc """
   Respond to ready and alive checks
 
@@ -9,8 +9,8 @@ defmodule HealthCheckPlug do
 
   ## Examples
   ```
-  plug HealthCheckPlug, path: "/alivez"
-  plug HealthCheckPlug, path: "/readyz"
+  plug PlugHealth, path: "/alivez"
+  plug PlugHealth, path: "/readyz"
   ```
   """
 
@@ -21,8 +21,8 @@ defmodule HealthCheckPlug do
   def defaults do
     [
       path: "/health",
-      respond_func: &HealthCheckPlug.respond/2,
-      check_func: &HealthCheckPlug.check/1
+      respond_func: &__MODULE__.respond/2,
+      check_func: &__MODULE__.check/1
     ]
   end
 
@@ -36,7 +36,9 @@ defmodule HealthCheckPlug do
       true ->
         result = opts[:check_func].(conn)
         opts[:respond_func].(conn, result)
-      false -> conn
+
+      false ->
+        conn
     end
   end
 

--- a/lib/plug_health.ex
+++ b/lib/plug_health.ex
@@ -21,8 +21,8 @@ defmodule PlugHealth do
   def defaults do
     [
       path: "/health",
-      respond_func: &__MODULE__.respond/2,
-      check_func: &__MODULE__.check/1
+      check_func: &__MODULE__.check/1,
+      respond_func: &__MODULE__.respond/2
     ]
   end
 
@@ -44,6 +44,8 @@ defmodule PlugHealth do
 
   def call(conn, _opts), do: conn
 
+  def check(_conn), do: true
+
   def respond(conn, true = _check_result) do
     conn
     |> put_resp_content_type("application/json", nil)
@@ -57,6 +59,4 @@ defmodule PlugHealth do
     |> send_resp(:service_unavailable, ~s({"healthy": false}))
     |> halt()
   end
-
-  def check(_conn), do: true
 end

--- a/mix.exs
+++ b/mix.exs
@@ -31,7 +31,7 @@ defmodule PlugHealth.MixProject do
 
   defp description do
     """
-    An elixir plug for handling health and ready endpoints
+    A plug for health check, which can be used for liveness or readiness probes.
     """
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,4 +1,4 @@
-defmodule HealthCheckPlug.MixProject do
+defmodule PlugHealth.MixProject do
   use Mix.Project
 
   def project do

--- a/mix.exs
+++ b/mix.exs
@@ -1,18 +1,21 @@
 defmodule PlugHealth.MixProject do
   use Mix.Project
 
+  @version "1.0.0"
+  @source_url "https://github.com/gabrieltaylor/plug_health"
+  @description "A plug for health check, which can be used for liveness or readiness probes."
+
   def project do
     [
       app: :plug_health,
-      version: "0.1.2",
+      version: @version,
       elixir: "~> 1.9",
       deps: deps(),
-      description: description(),
+      description: @description,
+      homepage_url: @source_url,
       package: package(),
-      source_url: "https://github.com/gabrieltaylor/plug_health",
-      docs: [
-        extras: ~W(README.md)
-      ]
+      aliases: aliases(),
+      docs: docs()
     ]
   end
 
@@ -29,20 +32,33 @@ defmodule PlugHealth.MixProject do
     ]
   end
 
-  defp description do
-    """
-    A plug for health check, which can be used for liveness or readiness probes.
-    """
-  end
-
   defp package do
     [
       files: ~w(lib mix.exs README.md LICENSE),
       maintainers: ["Gabriel Taylor Russ"],
       licenses: ["MIT"],
       links: %{
-        "Github" => "http://github.com/gabrieltaylor/plug_health"
+        "GitHub" => @source_url
       }
+    ]
+  end
+
+  defp aliases do
+    [publish: ["hex.publish", "tag"], tag: &tag_release/1]
+  end
+
+  defp tag_release(_) do
+    Mix.shell().info("Tagging release as #{@version}")
+    System.cmd("git", ["tag", @version])
+    System.cmd("git", ["push", "--tags"])
+  end
+
+  defp docs do
+    [
+      extras: ~W(README.md),
+      main: "readme",
+      source_url: @source_url,
+      source_ref: @version
     ]
   end
 end

--- a/test/plug_health_test.exs
+++ b/test/plug_health_test.exs
@@ -1,82 +1,82 @@
-defmodule HealthCheckPlugTest do
+defmodule PlugHealthTest do
   use ExUnit.Case, async: true
   use Plug.Test
   import Plug.Conn, only: [get_resp_header: 2]
 
   test "responds to /health by default" do
-    opts = HealthCheckPlug.init([])
+    opts = PlugHealth.init([])
 
     conn =
       :get
       |> conn("/health")
-      |> HealthCheckPlug.call(opts)
+      |> PlugHealth.call(opts)
 
     assert conn.halted
   end
 
   test "does not respond to /other-paths by default" do
-    opts = HealthCheckPlug.init([])
+    opts = PlugHealth.init([])
 
     conn =
       :get
       |> conn("/other-paths")
-      |> HealthCheckPlug.call(opts)
+      |> PlugHealth.call(opts)
 
     refute conn.halted
   end
 
   test "sets the response body" do
-    opts = HealthCheckPlug.init([])
+    opts = PlugHealth.init([])
 
     conn =
       :get
       |> conn("/health")
-      |> HealthCheckPlug.call(opts)
+      |> PlugHealth.call(opts)
 
     assert conn.resp_body == ~s({"healthy": true})
   end
 
   test "sets the content type" do
-    opts = HealthCheckPlug.init([])
+    opts = PlugHealth.init([])
 
     conn =
       :get
       |> conn("/health")
-      |> HealthCheckPlug.call(opts)
+      |> PlugHealth.call(opts)
 
     assert ["application/json"] == get_resp_header(conn, "content-type")
   end
 
   test "supports setting the path in options" do
-    opts = HealthCheckPlug.init([path: "/foo"])
+    opts = PlugHealth.init(path: "/foo")
 
     conn =
       :get
       |> conn("/foo")
-      |> HealthCheckPlug.call(opts)
+      |> PlugHealth.call(opts)
 
     assert conn.halted
   end
 
   test "supports setting the response function in options" do
-    opts = HealthCheckPlug.init([respond_func: &test_respond_func/2])
+    opts = PlugHealth.init(respond_func: &test_respond_func/2)
 
     conn =
       :get
       |> conn("/health")
-      |> HealthCheckPlug.call(opts)
+      |> PlugHealth.call(opts)
 
     assert conn.resp_body == ~s({"hello-from-the-test": true})
     assert conn.halted
   end
 
   test "supports setting the check function in options" do
-    opts = HealthCheckPlug.init(check_func: fn _conn -> true end)
+    opts = PlugHealth.init(check_func: fn _conn -> true end)
 
     conn =
       :get
       |> conn("/health")
-      |> HealthCheckPlug.call(opts)
+      |> PlugHealth.call(opts)
 
     assert conn.resp_body == ~s({"healthy": true})
     assert conn.halted
@@ -87,6 +87,7 @@ defmodule HealthCheckPlugTest do
     |> Plug.Conn.send_resp(:ok, ~s({"hello-from-the-test": true}))
     |> Plug.Conn.halt()
   end
+
   def test_respond_func(conn, false) do
     conn
     |> Plug.Conn.send_resp(:service_unavailable, ~s({"hello-from-the-test": false}))


### PR DESCRIPTION
Hey, @gabrieltaylor.

I checked many libraries doing health check on [hex.pm](https://hex.pm/). And, I think this library is the best.

I like the design of `:respond_func` and `:check_func` option, which makes this library very flexible.

But I think this library could be even better.

I don't want to create another library that is not maintained by anyone, so I think it's better to contribute code to this library.


## What I want to improve

### rename module name to `PlugHealth`

The package name is `plug_health` which is good, but the module name is `HealthCheckPlug` which doesn't match the package name.

At first, I think we should change the module name to `Plug.Health`. But, after reading [Avoid defining modules that are not in your "namespace"](https://hexdocs.pm/elixir/1.13/library-guidelines.html#avoid-defining-modules-that-are-not-in-your-namespace). I think it's better to name it as `PlugHealth`.

### adjust the description

Previously, the description is `An elixir plug for handling health and ready endpoints`.

I have a more abstract name for this - `A plug for health check, which can be used for liveness or readiness probes.`

### improve docs

+ add new section - usage
+ add the reason why this plug should be placed in endpoint.
+ add new section - license
+ adjust options section, make it more readable.

## release a version

I changed a lot of things, which could make troubles for others. So, I think it's better to bump a new major version, such as `1.0.0`.

## improve `mix.exs`

+ add `mix publish` which makes publishing packages easier.
+ improve docs setting

---

That's a lot of modifications indeed, and I don't expect you to like all of them

But, if you don't like them, let me know. I will come back to edit. ;)
